### PR TITLE
Add Genre Tags Functionality to Watch History Page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,6 +1,9 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Oooh+Baby&display=swap" rel="stylesheet">
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/src/components/WatchedMovies.tsx
+++ b/frontend/src/components/WatchedMovies.tsx
@@ -44,18 +44,23 @@ const WatchedMovies = () => {
       {loading && <p>Loading...</p>}
       {error && <p className="search-error">{error}</p>}
 
-      <select
-        value={selectedGenre ?? ""}
-        onChange={(e) => setSelectedGenre(e.target.value || null)}
-        className="genre-filter"
-      >
-        <option value="">All Genres</option>
+      <div className="genre-tags">
+        <span
+          className={`genre-tag ${selectedGenre === null ? "selected" : ""}`}
+          onClick={() => setSelectedGenre(null)}
+        >
+          All Genres
+        </span>
         {uniqueGenres.map((genre) => (
-            <option key={genre} value={genre}>
-                {genre}
-            </option>
+          <span
+            key={genre}
+            className={`genre-tag ${selectedGenre === genre ? "selected" : ""}`}
+            onClick={() => setSelectedGenre(genre)}
+          >
+            {genre}
+          </span>
         ))}
-      </select>
+      </div>
 
       {filteredMovies.length > 0 && (
         <div className="movies-grid">

--- a/frontend/src/components/WatchedMovies.tsx
+++ b/frontend/src/components/WatchedMovies.tsx
@@ -7,11 +7,11 @@ const WatchedMovies = () => {
   const [movies, setMovies] = useState<Movie[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [selectedGenre, setSelectedGenre] = useState<string | null>(null);
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
 
   const uniqueGenres = Array.from(
     new Set(movies.flatMap((movie) => movie.genres.map((g) => g.name)))
-  );
+  ).sort((a, b) => a.localeCompare(b));
 
   useEffect(() => {
     const getMovies = async () => {
@@ -31,31 +31,40 @@ const WatchedMovies = () => {
     getMovies();
   }, []);
 
-  const filteredMovies = selectedGenre
-    ? movies.filter((movie) =>
-        movie.genres.some((genre) => genre.name === selectedGenre)
-      )
-    : movies;
+  const filteredMovies =
+    selectedGenres.length > 0
+      ? movies.filter((movie) =>
+          movie.genres.some((genre) => selectedGenres.includes(genre.name))
+        )
+      : movies;
+
+  const toggleGenre = (genre: string) => {
+    setSelectedGenres((prev) =>
+      prev.includes(genre)
+        ? prev.filter((g) => g !== genre)
+        : [...prev, genre]
+    );
+  };
 
   return (
     <div className="search-container">
-      <h2 className="search-heading">Watched</h2>
+      <h2 className="search-heading dirty-dancing-title-alt1">Watch History</h2>
 
       {loading && <p>Loading...</p>}
       {error && <p className="search-error">{error}</p>}
 
       <div className="genre-tags">
         <span
-          className={`genre-tag ${selectedGenre === null ? "selected" : ""}`}
-          onClick={() => setSelectedGenre(null)}
+          className={`genre-tag ${selectedGenres.length === 0 ? "selected" : ""}`}
+          onClick={() => setSelectedGenres([])}
         >
           All Genres
         </span>
         {uniqueGenres.map((genre) => (
           <span
             key={genre}
-            className={`genre-tag ${selectedGenre === genre ? "selected" : ""}`}
-            onClick={() => setSelectedGenre(genre)}
+            className={`genre-tag ${selectedGenres.includes(genre) ? "selected" : ""}`}
+            onClick={() => toggleGenre(genre)}
           >
             {genre}
           </span>

--- a/frontend/src/components/WatchedMovies.tsx
+++ b/frontend/src/components/WatchedMovies.tsx
@@ -48,7 +48,7 @@ const WatchedMovies = () => {
 
   return (
     <div className="search-container">
-      <h2 className="search-heading dirty-dancing-title-alt1">Watch History</h2>
+      <h2 className="search-heading oooh-baby-regular">Watch History</h2>
 
       {loading && <p>Loading...</p>}
       {error && <p className="search-error">{error}</p>}

--- a/frontend/src/components/css/SearchMovie.css
+++ b/frontend/src/components/css/SearchMovie.css
@@ -97,3 +97,31 @@
   border-radius: 4px;
   border: 1px solid #ccc;
 }
+
+.genre-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  justify-content: center;
+}
+
+.genre-tag {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #ccc;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  background-color: #f3f4f6;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.genre-tag:hover {
+  background-color: #e5e7eb;
+}
+
+.genre-tag.selected {
+  background-color: #2563eb;
+  color: white;
+  border-color: #1e40af;
+}

--- a/frontend/src/components/css/SearchMovie.css
+++ b/frontend/src/components/css/SearchMovie.css
@@ -125,3 +125,26 @@
   color: white;
   border-color: #1e40af;
 }
+
+.dirty-dancing-title {
+  font-family: 'Pacifico', cursive; /* swap in a closer match if you find a better font */
+  font-size: 4rem;
+  color: #a02ebf; /* purple-magenta similar to the logo */
+  font-style: italic;
+  transform: rotate(-5deg);
+  letter-spacing: 2px;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.dirty-dancing-title-alt1 {
+  font-family: 'Pacifico', cursive; /* swap in a closer match if you find a better font */
+  font-size: 4rem;
+  color: #a02ebf; /* purple-magenta similar to the logo */
+  font-style: italic;
+  transform: rotate(-5deg);
+  letter-spacing: 2px;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
+  background: linear-gradient(to right, #a02ebf, #f048b3);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/frontend/src/components/css/SearchMovie.css
+++ b/frontend/src/components/css/SearchMovie.css
@@ -126,25 +126,39 @@
   border-color: #1e40af;
 }
 
+/* Dirty Dancing Title Style #1 - Unused */
 .dirty-dancing-title {
-  font-family: 'Pacifico', cursive; /* swap in a closer match if you find a better font */
+  font-family: 'Pacifico', cursive;
   font-size: 4rem;
-  color: #a02ebf; /* purple-magenta similar to the logo */
+  color: #a02ebf;
   font-style: italic;
   transform: rotate(-5deg);
   letter-spacing: 2px;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
 }
 
-.dirty-dancing-title-alt1 {
-  font-family: 'Pacifico', cursive; /* swap in a closer match if you find a better font */
+/* Dirty Dancing Title Style #2 - Unused */
+.dirty-dancing-title-alt {
+  font-family: 'Pacifico', cursive;
   font-size: 4rem;
-  color: #a02ebf; /* purple-magenta similar to the logo */
+  color: #a02ebf;
   font-style: italic;
   transform: rotate(-5deg);
   letter-spacing: 2px;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
   background: linear-gradient(to right, #a02ebf, #f048b3);
+  background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+}
+
+/* Dirty Dancing Title Style #3 - Unused */
+.oooh-baby-regular {
+  font-family: "Oooh Baby", cursive;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 6rem;
+  color: #a02ebf;
+  letter-spacing: 2px;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
This pull request introduces enhancements to the frontend of the application, focusing on improving the user experience for filtering watched movies by genres and updating the visual styling. The key changes include enabling multi-genre selection, adding new styling for genre tags, and incorporating a custom font for the "Watch History" heading.

### Functional Improvements:
* Updated `WatchedMovies` component to support multi-genre selection instead of single-genre filtering. This includes replacing `selectedGenre` with `selectedGenres` (an array) and adding a `toggleGenre` function to manage genre selection. [[1]](diffhunk://#diff-cd9153506318ff1ed483be8398e3b1bef332eb7df19444c21705eb55cbd05d2bL10-R14) [[2]](diffhunk://#diff-cd9153506318ff1ed483be8398e3b1bef332eb7df19444c21705eb55cbd05d2bL34-R72)
* Replaced the dropdown genre filter with interactive genre tags, allowing users to select/deselect genres by clicking on them.

### Styling Enhancements:
* Added new styles for genre tags in `SearchMovie.css`, including hover effects, selected state styling, and a responsive layout for the tags.
* Introduced a custom font, "Oooh Baby," for the "Watch History" heading, and updated the heading's class to apply the new font style. [[1]](diffhunk://#diff-959f9cada636604db33bc1ba82fed347457dcb032c37ac195b4343c5f0ea6e72R4-R6) [[2]](diffhunk://#diff-cd9153506318ff1ed483be8398e3b1bef332eb7df19444c21705eb55cbd05d2bL34-R72)

### Additional Notes:
* Included unused CSS classes for alternative title styles, which could be utilized in the future.